### PR TITLE
Edited message acceptance mask setting call to use an OR instead of XOR

### DIFF
--- a/CAN_Acquisition.cpp
+++ b/CAN_Acquisition.cpp
@@ -140,8 +140,9 @@ void cAcquireCAN::addMessage(cCANFrame *frame, ACQ_FRAME_TYPE type)
 
 		//we need to setup the masks for the ID's in the receive mailbox
 		//receive mailbox is mailbox #0
-        MAM_mask  = ~(MID_mask^frame->ID);
-        MID_mask |= frame->ID;
+        MAM_mask  = ~(MID_mask|frame->ID);
+		
+	    MID_mask |= frame->ID;
 
 		//program registers
 		C->mailbox_set_accept_mask(0, MAM_mask, false);

--- a/CAN_Acquisition.cpp
+++ b/CAN_Acquisition.cpp
@@ -30,7 +30,9 @@ cAcquireCAN::cAcquireCAN(ACQ_CAN_PORT _portNumber)
 	count        = 0;
 	_1mSCntr     = 0;
 	_10mSCntr    = 0;
+	_25mSCntr	 = 0;
 	_100mSCntr   = 0;
+	_500mSCntr	 = 0;
 	_1000mSCntr  = 0;
 	usTsliceMax  = 0;
 	usTslice     = 0;
@@ -145,8 +147,8 @@ void cAcquireCAN::addMessage(cCANFrame *frame, ACQ_FRAME_TYPE type)
 	    MID_mask |= frame->ID;
 
 		//program registers
-		C->mailbox_set_accept_mask(0, MAM_mask, false);
-		C->mailbox_set_id(0, MID_mask, false);
+		C->mailbox_set_accept_mask(0, MAM_mask, frame->ext);
+		C->mailbox_set_id(0, MID_mask, frame->ext);
 	}
 
 }
@@ -212,8 +214,8 @@ void cAcquireCAN::TXmsg(cCANFrame *I)
 	if (validFrame)
 	{
 		//set CAN ID  for mailbox
-		C->mailbox_set_id(1, I->ID, false);
-
+		C->mailbox_set_id(1, I->ID, I->ext);
+		C->mailbox_set_datalen(1, I->dlc);
 		//load payloads	for this mailbox 
 		C->mailbox_set_datal(1,I->U.P.lowerPayload);
 		C->mailbox_set_datah(1, I->U.P.upperPayload);
@@ -223,6 +225,7 @@ void cAcquireCAN::TXmsg(cCANFrame *I)
 
 		//increment transmit counter
 		TxCtr += 1; 
+		I->isFresh = 0;
 	}
 }
 
@@ -268,6 +271,8 @@ void cAcquireCAN::RXmsg()
 					rxMsgs[i]->U.b[7] = newFrame.data[7];
 					//NOTE: re-write in future versions for U32 transfers
 
+					// indicate that the message is fresh; user code can set it as un-fresh to monitor updates
+					rxMsgs[i]->isFresh = 1;					
 					//increment receive counter
 					RxCtr += 1;
 				}
@@ -329,6 +334,13 @@ void cAcquireCAN::run(ACQ_MODE mode)
 		}
 
 		//transmit the "free-running" CAN messages
+		//200Hz
+		if ((_1mSCntr - _5mSCntr) >= 5)
+		{
+			runRates(_200Hz_Rate);
+			_5mSCntr = _1mSCntr;
+		}
+		
 		//100Hz
 		if ((_1mSCntr - _10mSCntr) >= 10)
 		{
@@ -336,6 +348,15 @@ void cAcquireCAN::run(ACQ_MODE mode)
 			_10mSCntr = _1mSCntr;
 		}
 
+		
+		//40Hz
+		if ((_1mSCntr - _25mSCntr) >= 25)
+		{
+			runRates(_40Hz_Rate);
+			_25mSCntr = _1mSCntr;
+		}
+		
+		
 		//10Hz
 		if ((_1mSCntr - _100mSCntr) >= 100)
 		{
@@ -350,6 +371,13 @@ void cAcquireCAN::run(ACQ_MODE mode)
 			_200mSCntr = _1mSCntr;
 		}
 
+		//5Hz
+		if ((_1mSCntr - _500mSCntr) >=  500)
+		{
+			runRates(_2Hz_Rate);
+			_500mSCntr = _1mSCntr;
+		}
+		
 		//1Hz
 		if (_1mSCntr >= 1000)
 		{

--- a/CAN_Acquisition.h
+++ b/CAN_Acquisition.h
@@ -62,9 +62,12 @@ enum ACQ_BAUD_RATE
 enum ACQ_RATE_CAN
 {
 	_1Hz_Rate    	= 1000,
+	_2Hz_Rate    	= 500,
 	_5Hz_Rate    	= 200,
 	_10Hz_Rate   	= 100,
+	_40Hz_Rate		= 25,
 	_100Hz_Rate  	= 10,
+	_200Hz_Rate		= 5,
 	QUERY_MSG    	= 0xFFFF
 };
 
@@ -98,6 +101,16 @@ enum ACQ_MODE
 	TIMER_2mS
 };
 
+
+/**
+ * This enum allows the programmer to force use of an 11 bit (standard) or 29 bit (extended) identifier
+ * Plugs into due_can library's extended ID functionality
+ */
+enum EXT_FLAG
+{
+	EXTENDED = 1 ,
+	STANDARD = 0
+};
 
 /**
  * This sturct represents a full CAN frame. The ID, payload (message), transmission rate, and CAN ID index are represented.
@@ -142,6 +155,15 @@ public:
 	 * This is the periodic transmission rate for this message
 	 */
 	ACQ_RATE_CAN rate;
+	
+	//  A uint8 holds the DLC set for TX.  A conditional to reject frames with wrong DLC would have to be added to the RX code for this to have effect on RX behavior
+	UINT8 dlc;
+	
+	//  A boolean flag to denote an extended frame. 
+	EXT_FLAG ext;
+	
+	//  A boolean to denote "fresh" data on rx or transmitted vs untransmitted data in tx.  Used in application code, tx rs subroutines
+	bool isFresh;
 
 	/**
 	 * This is a function that is called by the acquisition scheduler when a receive message matching this CAN ID has been received.
@@ -257,7 +279,7 @@ private:
 	 /**
 	 * counters used to determine # of mSecs that have elapsed
 	 */
-	 UINT16 _1mSCntr, _10mSCntr, _100mSCntr, _200mSCntr, _1000mSCntr, _queryCntr;
+	 UINT16 _1mSCntr, _5mSCntr, _10mSCntr, _25mSCntr, _100mSCntr, _200mSCntr, _500mSCntr, _1000mSCntr, _queryCntr;
 
 	/**
 	 * diagnostic timing varibles used to track the execution time of the scheduler


### PR DESCRIPTION
Edited message acceptance mask setting call to use an BITOR instead of BITXOR, allowed receipt of 3 standard messages.
(Use case detail: RX IDs 0x2CA, 0x230, 0x1D5, 0x230. Added in reverse order of priority, 0x230 was not seen with old code, seen with new code.)
